### PR TITLE
Upgrade dependencies and plugins to latest stable

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -15,6 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
         java: [17, 21]

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [17, 21]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -15,10 +15,9 @@ jobs:
     timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [17, 21]
+        java: [21]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -34,18 +33,3 @@ jobs:
       - run: java -version
       - run: mvn -version
       - run: mvn --errors --batch-mode clean install -Pqulice
-      - name: Dump test and pit reports on failure
-        if: failure()
-        shell: bash
-        run: |
-          set +e
-          echo "=== surefire reports ==="
-          for f in target/surefire-reports/*.txt target/surefire-reports/*.xml; do
-            [ -f "$f" ] || continue
-            echo "--- $f ---"
-            cat -- "$f"
-          done
-          echo "=== pit-reports/index.html ==="
-          [ -f target/pit-reports/index.html ] && head -200 target/pit-reports/index.html
-          echo "=== qulice reports ==="
-          find target -name "*.txt" -path "*qulice*" -exec cat -- {} \;

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -34,3 +34,18 @@ jobs:
       - run: java -version
       - run: mvn -version
       - run: mvn --errors --batch-mode clean install -Pqulice
+      - name: Dump test and pit reports on failure
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          echo "=== surefire reports ==="
+          for f in target/surefire-reports/*.txt target/surefire-reports/*.xml; do
+            [ -f "$f" ] || continue
+            echo "--- $f ---"
+            cat "$f"
+          done
+          echo "=== pit-reports/index.html ==="
+          [ -f target/pit-reports/index.html ] && cat target/pit-reports/index.html | head -200
+          echo "=== qulice/checkstyle reports ==="
+          find target -name "*.txt" -path "*qulice*" -exec cat {} \;

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -43,9 +43,9 @@ jobs:
           for f in target/surefire-reports/*.txt target/surefire-reports/*.xml; do
             [ -f "$f" ] || continue
             echo "--- $f ---"
-            cat "$f"
+            cat -- "$f"
           done
           echo "=== pit-reports/index.html ==="
-          [ -f target/pit-reports/index.html ] && cat target/pit-reports/index.html | head -200
-          echo "=== qulice/checkstyle reports ==="
-          find target -name "*.txt" -path "*qulice*" -exec cat {} \;
+          [ -f target/pit-reports/index.html ] && head -200 target/pit-reports/index.html
+          echo "=== qulice reports ==="
+          find target -name "*.txt" -path "*qulice*" -exec cat -- {} \;

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.68.0</version>
+    <version>0.73.1</version>
   </parent>
   <groupId>org.eolang</groupId>
   <artifactId>xax</artifactId>
@@ -66,17 +66,17 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-xml</artifactId>
-      <version>0.33.5</version>
+      <version>0.35.0</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <version>0.57.0</version>
+      <version>0.61.0</version>
     </dependency>
     <dependency>
       <groupId>com.yegor256</groupId>
@@ -86,7 +86,13 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.11.4</version>
+      <version>6.0.3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opentest4j</groupId>
+      <artifactId>opentest4j</artifactId>
+      <version>1.3.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -98,7 +104,7 @@
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <version>12.8</version>
+      <version>12.9</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -122,13 +128,13 @@
     <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>jping</artifactId>
-      <version>0.0.3</version>
+      <version>0.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.51.6</version>
+      <version>0.61.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -137,7 +143,7 @@
       <plugin>
         <groupId>org.pitest</groupId>
         <artifactId>pitest-maven</artifactId>
-        <version>1.20.0</version>
+        <version>1.23.1</version>
         <executions>
           <execution>
             <goals>
@@ -168,7 +174,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.24.0</version>
+            <version>0.27.6</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>

--- a/src/main/java/org/eolang/xax/XtSticky.java
+++ b/src/main/java/org/eolang/xax/XtSticky.java
@@ -14,7 +14,6 @@ import java.util.function.Supplier;
 /**
  * A decorator of {@link Xtory} that guarantees any method is only
  * delegated to the decoratee only once.
- *
  * @since 0.1.0
  */
 public final class XtSticky implements Xtory {
@@ -27,7 +26,7 @@ public final class XtSticky implements Xtory {
     /**
      * The cache.
      */
-    private final ConcurrentHashMap<String, Object> cache;
+    private final Map<String, Object> cache;
 
     /**
      * Ctor.
@@ -77,5 +76,4 @@ public final class XtSticky implements Xtory {
             s -> supplier.get()
         );
     }
-
 }

--- a/src/main/java/org/eolang/xax/XtStrict.java
+++ b/src/main/java/org/eolang/xax/XtStrict.java
@@ -14,7 +14,6 @@ import java.util.Map;
  * A decorator of {@link Xtory} that checks the validity
  * of XML against the XSD schema attached to it, right before
  * returning it at {@link Xtory#after()} and {@link Xtory#before()}.
- *
  * @since 0.4.0
  */
 public final class XtStrict implements Xtory {

--- a/src/main/java/org/eolang/xax/XtStrictAfter.java
+++ b/src/main/java/org/eolang/xax/XtStrictAfter.java
@@ -14,7 +14,6 @@ import java.util.Map;
  * A decorator of {@link Xtory} that checks the validity
  * of XML against the XSD schema attached to it, right before
  * returning it at {@link Xtory#after()}.
- *
  * @since 0.4.0
  */
 public final class XtStrictAfter implements Xtory {

--- a/src/main/java/org/eolang/xax/XtStrictBefore.java
+++ b/src/main/java/org/eolang/xax/XtStrictBefore.java
@@ -14,7 +14,6 @@ import java.util.Map;
  * A decorator of {@link Xtory} that checks the validity
  * of XML against the XSD schema attached to it, right before
  * returning it at {@link Xtory#before()}.
- *
  * @since 0.4.0
  */
 public final class XtStrictBefore implements Xtory {

--- a/src/main/java/org/eolang/xax/XtYaml.java
+++ b/src/main/java/org/eolang/xax/XtYaml.java
@@ -13,18 +13,17 @@ import com.yegor256.xsline.StXSL;
 import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.Train;
 import com.yegor256.xsline.Xsline;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.Map;
 import org.yaml.snakeyaml.Yaml;
 
 /**
  * A story parsed from YAML and then processed through XSL
  * stylesheets.
- *
  * @since 0.1.0
  */
 public final class XtYaml implements Xtory {
@@ -133,7 +132,7 @@ public final class XtYaml implements Xtory {
                             new XSLDocument(Paths.get(sheet.substring(7)))
                         )
                     );
-                } catch (final FileNotFoundException ex) {
+                } catch (final IOException ex) {
                     throw new IllegalArgumentException(ex);
                 }
             } else {
@@ -150,11 +149,10 @@ public final class XtYaml implements Xtory {
         if (asserts == null) {
             asserts = Arrays.asList();
         }
-        final Collection<String> xpaths = new LinkedList<>();
+        final Collection<String> xpaths = new ArrayList<>(0);
         for (final String xpath : (Iterable<String>) asserts) {
             xpaths.add(xpath);
         }
         return xpaths;
     }
-
 }

--- a/src/main/java/org/eolang/xax/Xtory.java
+++ b/src/main/java/org/eolang/xax/Xtory.java
@@ -11,7 +11,6 @@ import java.util.Map;
 
 /**
  * A story about XML processed through XSL stylesheets.
- *
  * @since 0.4.0
  */
 public interface Xtory {
@@ -48,9 +47,9 @@ public interface Xtory {
 
     /**
      * A parser of a {@link String} to {@link XML}.
-     *
      * @since 0.4.0
      */
+    @FunctionalInterface
     interface Parser {
 
         /**
@@ -60,6 +59,5 @@ public interface Xtory {
          * @throws Exception If fails
          */
         XML parse(String input) throws Exception;
-
     }
 }

--- a/src/main/java/org/eolang/xax/XtoryMatcher.java
+++ b/src/main/java/org/eolang/xax/XtoryMatcher.java
@@ -6,8 +6,8 @@ package org.eolang.xax;
 
 import com.jcabi.xml.XML;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.Map;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -16,10 +16,8 @@ import org.junit.jupiter.api.Assumptions;
 
 /**
  * Hamcrest matcher for a YAML story.
- *
  * @since 0.1.0
  */
-@SuppressWarnings("PMD.ConstructorShouldDoInitialization")
 public final class XtoryMatcher extends BaseMatcher<Xtory> {
 
     /**
@@ -79,7 +77,7 @@ public final class XtoryMatcher extends BaseMatcher<Xtory> {
         Assumptions.assumeTrue(xtory.map().get("skip") == null);
         final XML after = xtory.xsline().pass(xtory.before());
         final Collection<Map.Entry<String, Boolean>> xpaths =
-            new LinkedList<>();
+            new ArrayList<>(0);
         int failures = 0;
         for (final String xpath : xtory.asserts()) {
             final boolean success = !after.nodes(xpath).isEmpty();
@@ -92,8 +90,9 @@ public final class XtoryMatcher extends BaseMatcher<Xtory> {
             "All %d XPath expressions matched",
             xpaths.size()
         );
-        final StringBuilder sum = new StringBuilder(1024)
-            .append(String.format("%d XPath expression(s) failed:\n", failures));
+        final StringBuilder sum = new StringBuilder(1024).append(
+            String.format("%d XPath expression(s) failed:%n", failures)
+        );
         for (final Map.Entry<String, Boolean> ent : xpaths) {
             sum.append("  ");
             if (ent.getValue()) {
@@ -101,19 +100,25 @@ public final class XtoryMatcher extends BaseMatcher<Xtory> {
             } else {
                 sum.append("FAIL");
             }
-            sum.append(": ").append(ent.getKey()).append('\n');
+            sum.append(": ").append(ent.getKey()).append(System.lineSeparator());
         }
-        sum
-            .append("\nXML before XSL transformation:\n  ")
-            .append(xtory.before().toString().replace("\n", "\n  "))
-            .append(
-                String.format(
-                    "\nXML after XSL transformation (%d->%d chars):\n  ",
-                    xtory.before().toString().length(),
-                    after.toString().length()
-                )
+        sum.append(
+            String.format("%nXML before XSL transformation:%n  ")
+        ).append(
+            xtory.before().toString().replace(
+                System.lineSeparator(), String.format("%n  ")
             )
-            .append(after.toString().replace("\n", "\n  "));
+        ).append(
+            String.format(
+                "%nXML after XSL transformation (%d->%d chars):%n  ",
+                xtory.before().toString().length(),
+                after.toString().length()
+            )
+        ).append(
+            after.toString().replace(
+                System.lineSeparator(), String.format("%n  ")
+            )
+        );
         this.summary = sum.toString();
         this.match = true;
         for (final Map.Entry<String, Boolean> ent : xpaths) {
@@ -139,8 +144,7 @@ public final class XtoryMatcher extends BaseMatcher<Xtory> {
         if (this.match) {
             this.extra.describeMismatch(story, desc);
         } else {
-            desc.appendText("\n").appendText(this.summary);
+            desc.appendText(System.lineSeparator()).appendText(this.summary);
         }
     }
-
 }

--- a/src/main/java/org/eolang/xax/package-info.java
+++ b/src/main/java/org/eolang/xax/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * XPath Assertions for XSL.
- *
  * @since 0.0.1
  */
 package org.eolang.xax;

--- a/src/test/java/org/eolang/xax/XtStickyTest.java
+++ b/src/test/java/org/eolang/xax/XtStickyTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link XtSticky}.
- *
  * @since 0.1.0
  */
 final class XtStickyTest {
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void parsesAndTransforms() throws Exception {
         final Xtory xtory = new XtSticky(
             new XtYaml(
@@ -32,5 +32,4 @@ final class XtStickyTest {
             XhtmlMatchers.hasXPaths(xtory.asserts())
         );
     }
-
 }

--- a/src/test/java/org/eolang/xax/XtStrictAfterTest.java
+++ b/src/test/java/org/eolang/xax/XtStrictAfterTest.java
@@ -14,13 +14,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link XtStrictAfter}.
- *
  * @since 0.1.0
  */
 final class XtStrictAfterTest {
 
     @Test
     @ExtendWith(WeAreOnline.class)
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void parsesAndTransforms() throws Exception {
         final Xtory xtory = new XtStrictAfter(
             new XtYaml(
@@ -35,5 +35,4 @@ final class XtStrictAfterTest {
             XhtmlMatchers.hasXPaths(xtory.asserts())
         );
     }
-
 }

--- a/src/test/java/org/eolang/xax/XtStrictBeforeTest.java
+++ b/src/test/java/org/eolang/xax/XtStrictBeforeTest.java
@@ -14,13 +14,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link XtStrictBefore}.
- *
  * @since 0.1.0
  */
 final class XtStrictBeforeTest {
 
     @Test
     @ExtendWith(WeAreOnline.class)
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void parsesAndTransforms() throws Exception {
         final Xtory xtory = new XtStrictBefore(
             new XtYaml(
@@ -35,5 +35,4 @@ final class XtStrictBeforeTest {
             XhtmlMatchers.hasXPaths(xtory.asserts())
         );
     }
-
 }

--- a/src/test/java/org/eolang/xax/XtStrictTest.java
+++ b/src/test/java/org/eolang/xax/XtStrictTest.java
@@ -14,13 +14,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link XtStrict}.
- *
  * @since 0.1.0
  */
 final class XtStrictTest {
 
     @Test
     @ExtendWith(WeAreOnline.class)
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void parsesAndTransforms() throws Exception {
         final Xtory xtory = new XtStrict(
             new XtYaml(
@@ -35,5 +35,4 @@ final class XtStrictTest {
             XhtmlMatchers.hasXPaths(xtory.asserts())
         );
     }
-
 }

--- a/src/test/java/org/eolang/xax/XtoryMatcherTest.java
+++ b/src/test/java/org/eolang/xax/XtoryMatcherTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Test case for {@link XtoryMatcher}.
- *
  * @since 0.1.0
  */
 final class XtoryMatcherTest {
@@ -96,5 +95,4 @@ final class XtoryMatcherTest {
             Matchers.not(new XtoryMatcher())
         );
     }
-
 }

--- a/src/test/java/org/eolang/xax/XtoryTest.java
+++ b/src/test/java/org/eolang/xax/XtoryTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Xtory}.
- *
  * @since 0.1.0
  */
 final class XtoryTest {
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void parsesAndTransforms() throws Exception {
         final Xtory xtory = new XtYaml(
             new TextOf(
@@ -30,5 +30,4 @@ final class XtoryTest {
             XhtmlMatchers.hasXPaths(xtory.asserts())
         );
     }
-
 }

--- a/src/test/java/org/eolang/xax/package-info.java
+++ b/src/test/java/org/eolang/xax/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * XPath Assertions for XSL.
- *
  * @since 0.0.1
  */
 package org.eolang.xax;

--- a/src/test/resources/org/eolang/xax/packs/simple-eo.yaml
+++ b/src/test/resources/org/eolang/xax/packs/simple-eo.yaml
@@ -4,7 +4,5 @@
 input: |
   # No comments.
   [] > foo
-    QQ.io.stdout > @
-      "Hello, world!"
 asserts:
-  - /program/objects/o
+  - /object/o[@name='foo']


### PR DESCRIPTION
@yegor256 — this is a dependency-upgrade PR for `objectionary/xax` with all CI green.

## Why

Most direct dependencies, plugins, and the parent POM were several minor/major versions behind the current stable line. The pinned-version pattern means renovate produces one PR per artifact rather than one consolidated upgrade; this PR brings everything to current stable in one go and adjusts the source/tests/CI for the bits that changed shape.

## Versions bumped

- `com.jcabi:parent` 0.68.0 → 0.73.1 — drops JUnit 5 BOM in favor of JUnit 6
- `org.yaml:snakeyaml` 2.4 → 2.6
- `com.jcabi:jcabi-xml` 0.33.5 → 0.35.0
- `org.cactoos:cactoos` 0.57.0 → 0.61.0
- `org.junit.jupiter:junit-jupiter-api` 5.11.4 → 6.0.3 (matches the parent BOM)
- `net.sf.saxon:Saxon-HE` 12.8 → 12.9
- `com.yegor256:jping` 0.0.3 → 0.1.0
- `org.eolang:eo-parser` 0.51.6 → 0.61.0
- `org.pitest:pitest-maven` 1.20.0 → 1.23.1
- `com.qulice:qulice-maven-plugin` 0.24.0 → 0.27.6
- Added `org.opentest4j:opentest4j` 1.3.0 (`provided`) so `Assumptions.assumeTrue` resolves at compile time

## CI matrix

The matrix moves from `[ubuntu, windows, macos] × [11, 17]` to `[ubuntu, windows, macos] × [21]`:

- The new parent (0.71+) ships JUnit 6 in its BOM, which requires Java 17+, so Java 11 is no longer viable.
- `com.qulice:qulice-maven-plugin` 0.27.6 is now compiled with target Java 21 (class file 65) and fails to load on Java 17 with `UnsupportedClassVersionError`. Java 17 had to be dropped from the matrix to keep `-Pqulice` runnable.

## Code changes the upgrades forced

- `XtYaml`: catch `IOException` instead of `FileNotFoundException` — `jcabi-xml` 0.35 now declares the parent class on `XSLDocument(Path)`.
- `simple-eo.yaml`: regenerated for the new `eo-parser` 0.61 XMIR shape — root is `<object>` rather than `<program>/<objects>`, so the assertion is `/object/o[@name=foo]`. The previous EO snippet (`QQ.io.stdout > @ "Hello"`) is no longer valid syntax in 0.61, so I trimmed it to a minimal valid program.

## Code changes to satisfy qulice 0.27.6

The newer qulice has tightened several rules. I fixed the violations rather than adding suppressions, except where suppression was the right call (PMD false positives noted below):

- `JavadocEmptyLineBeforeTagCheck` — removed the empty line between class description and `@since` everywhere.
- `RegexpMultilineCheck` — removed empty lines before closing braces.
- `ProhibitLineSeparatorInStringsCheck` / `StringLiteralsConcatenationCheck` — replaced `"\n"` literals and `+ "  "` with `String.format("%n")` / `System.lineSeparator()`.
- `JdkObsolete` (Error Prone) and the qulice array-list-size rule — `LinkedList` → `ArrayList<>(0)` in `XtoryMatcher`/`XtYaml`.
- `LooseCoupling` — `XtSticky.cache` typed as `Map<String, Object>` (still backed by `ConcurrentHashMap`).
- `ImplicitFunctionalInterface` — `Xtory.Parser` now `@FunctionalInterface`.
- Dropped the now-unnecessary `@SuppressWarnings("PMD.ConstructorShouldDoInitialization")` on `XtoryMatcher`.
- Suppressed `PMD.UnitTestContainsTooManyAsserts` on the four single-`assertThat` tests where the matcher chain (`XhtmlMatchers.xhtml(...).hasXPaths(...)`) is now counted as multiple asserts. These tests genuinely contain one assertion each.

## Verification

All 12 CI checks are green on the head commit:

- `mvn` on `ubuntu-24.04`, `macos-15`, `windows-2022` (Java 21)
- `actionlint`, `copyrights`, `markdown-lint`, `ort`, `pdd`, `reuse`, `typos`, `xcop`, `yamllint`

Ready to merge.