### PR TITLE
Upgrade dependencies, plugins and GitHub Actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,18 +12,18 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
       - run: mvn install -Pjacoco
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: yegor256/copyrights-action@0.0.12
         with:
           globs: >-

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -19,5 +19,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v20.0.0
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v23.2.0

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [17, 21]
+        java: [21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [17, 21]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oss-review-toolkit/ort-ci-github-action@v1
         with:
           allow-dynamic-versions: 'true'

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: volodya-lombrozo/pdd-action@master

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: fsfe/reuse-action@v5
+      - uses: actions/checkout@v6
+      - uses: fsfe/reuse-action@v6

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.34.0
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1.46.1

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -10,12 +10,12 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: |-
           git fetch --tags --force && \
           latest=$(git tag --sort=creatordate | tail -1) && \
           sed -E -i "s/<version>[^<]+/<version>${latest}/g" README.md
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@v8
         with:
           sign-commits: true
           commit-message: 'new version in README'

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: g4s8/xcop-action@master

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ibiqlik/action-yamllint@v3

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.68.0</version>
+    <version>0.73.1</version>
   </parent>
   <groupId>org.eolang</groupId>
   <artifactId>xax</artifactId>
@@ -66,17 +66,17 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-xml</artifactId>
-      <version>0.33.5</version>
+      <version>0.35.0</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <version>0.57.0</version>
+      <version>0.61.0</version>
     </dependency>
     <dependency>
       <groupId>com.yegor256</groupId>
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.11.4</version>
+      <version>6.0.3</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <version>12.8</version>
+      <version>12.9</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-matchers</artifactId>
-      <version>1.8.0</version>
+      <version>1.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -122,13 +122,13 @@
     <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>jping</artifactId>
-      <version>0.0.3</version>
+      <version>0.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.51.6</version>
+      <version>0.61.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -137,7 +137,7 @@
       <plugin>
         <groupId>org.pitest</groupId>
         <artifactId>pitest-maven</artifactId>
-        <version>1.20.0</version>
+        <version>1.23.1</version>
         <executions>
           <execution>
             <goals>
@@ -168,7 +168,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.24.0</version>
+            <version>0.27.6</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>

--- a/src/main/java/org/eolang/xax/XtSticky.java
+++ b/src/main/java/org/eolang/xax/XtSticky.java
@@ -14,7 +14,6 @@ import java.util.function.Supplier;
 /**
  * A decorator of {@link Xtory} that guarantees any method is only
  * delegated to the decoratee only once.
- *
  * @since 0.1.0
  */
 public final class XtSticky implements Xtory {
@@ -27,7 +26,7 @@ public final class XtSticky implements Xtory {
     /**
      * The cache.
      */
-    private final ConcurrentHashMap<String, Object> cache;
+    private final Map<String, Object> cache;
 
     /**
      * Ctor.
@@ -77,5 +76,4 @@ public final class XtSticky implements Xtory {
             s -> supplier.get()
         );
     }
-
 }

--- a/src/main/java/org/eolang/xax/XtStrict.java
+++ b/src/main/java/org/eolang/xax/XtStrict.java
@@ -14,7 +14,6 @@ import java.util.Map;
  * A decorator of {@link Xtory} that checks the validity
  * of XML against the XSD schema attached to it, right before
  * returning it at {@link Xtory#after()} and {@link Xtory#before()}.
- *
  * @since 0.4.0
  */
 public final class XtStrict implements Xtory {

--- a/src/main/java/org/eolang/xax/XtStrictAfter.java
+++ b/src/main/java/org/eolang/xax/XtStrictAfter.java
@@ -14,7 +14,6 @@ import java.util.Map;
  * A decorator of {@link Xtory} that checks the validity
  * of XML against the XSD schema attached to it, right before
  * returning it at {@link Xtory#after()}.
- *
  * @since 0.4.0
  */
 public final class XtStrictAfter implements Xtory {

--- a/src/main/java/org/eolang/xax/XtStrictBefore.java
+++ b/src/main/java/org/eolang/xax/XtStrictBefore.java
@@ -14,7 +14,6 @@ import java.util.Map;
  * A decorator of {@link Xtory} that checks the validity
  * of XML against the XSD schema attached to it, right before
  * returning it at {@link Xtory#before()}.
- *
  * @since 0.4.0
  */
 public final class XtStrictBefore implements Xtory {

--- a/src/main/java/org/eolang/xax/XtYaml.java
+++ b/src/main/java/org/eolang/xax/XtYaml.java
@@ -13,7 +13,7 @@ import com.yegor256.xsline.StXSL;
 import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.Train;
 import com.yegor256.xsline.Xsline;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
@@ -24,7 +24,6 @@ import org.yaml.snakeyaml.Yaml;
 /**
  * A story parsed from YAML and then processed through XSL
  * stylesheets.
- *
  * @since 0.1.0
  */
 public final class XtYaml implements Xtory {
@@ -133,7 +132,7 @@ public final class XtYaml implements Xtory {
                             new XSLDocument(Paths.get(sheet.substring(7)))
                         )
                     );
-                } catch (final FileNotFoundException ex) {
+                } catch (final IOException ex) {
                     throw new IllegalArgumentException(ex);
                 }
             } else {
@@ -156,5 +155,4 @@ public final class XtYaml implements Xtory {
         }
         return xpaths;
     }
-
 }

--- a/src/main/java/org/eolang/xax/XtYaml.java
+++ b/src/main/java/org/eolang/xax/XtYaml.java
@@ -15,9 +15,9 @@ import com.yegor256.xsline.Train;
 import com.yegor256.xsline.Xsline;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.Map;
 import org.yaml.snakeyaml.Yaml;
 
@@ -149,7 +149,7 @@ public final class XtYaml implements Xtory {
         if (asserts == null) {
             asserts = Arrays.asList();
         }
-        final Collection<String> xpaths = new LinkedList<>();
+        final Collection<String> xpaths = new ArrayList<>(0);
         for (final String xpath : (Iterable<String>) asserts) {
             xpaths.add(xpath);
         }

--- a/src/main/java/org/eolang/xax/Xtory.java
+++ b/src/main/java/org/eolang/xax/Xtory.java
@@ -11,7 +11,6 @@ import java.util.Map;
 
 /**
  * A story about XML processed through XSL stylesheets.
- *
  * @since 0.4.0
  */
 public interface Xtory {
@@ -48,9 +47,9 @@ public interface Xtory {
 
     /**
      * A parser of a {@link String} to {@link XML}.
-     *
      * @since 0.4.0
      */
+    @FunctionalInterface
     interface Parser {
 
         /**
@@ -60,6 +59,5 @@ public interface Xtory {
          * @throws Exception If fails
          */
         XML parse(String input) throws Exception;
-
     }
 }

--- a/src/main/java/org/eolang/xax/XtoryMatcher.java
+++ b/src/main/java/org/eolang/xax/XtoryMatcher.java
@@ -16,10 +16,8 @@ import org.junit.jupiter.api.Assumptions;
 
 /**
  * Hamcrest matcher for a YAML story.
- *
  * @since 0.1.0
  */
-@SuppressWarnings("PMD.ConstructorShouldDoInitialization")
 public final class XtoryMatcher extends BaseMatcher<Xtory> {
 
     /**
@@ -92,8 +90,10 @@ public final class XtoryMatcher extends BaseMatcher<Xtory> {
             "All %d XPath expressions matched",
             xpaths.size()
         );
-        final StringBuilder sum = new StringBuilder(1024)
-            .append(String.format("%d XPath expression(s) failed:\n", failures));
+        final String sep = System.lineSeparator();
+        final StringBuilder sum = new StringBuilder(1024).append(
+            String.format("%d XPath expression(s) failed:%n", failures)
+        );
         for (final Map.Entry<String, Boolean> ent : xpaths) {
             sum.append("  ");
             if (ent.getValue()) {
@@ -101,19 +101,19 @@ public final class XtoryMatcher extends BaseMatcher<Xtory> {
             } else {
                 sum.append("FAIL");
             }
-            sum.append(": ").append(ent.getKey()).append('\n');
+            sum.append(": ").append(ent.getKey()).append(sep);
         }
-        sum
-            .append("\nXML before XSL transformation:\n  ")
-            .append(xtory.before().toString().replace("\n", "\n  "))
-            .append(
+        final String before = xtory.before().toString();
+        final String later = after.toString();
+        sum.append(sep).append("XML before XSL transformation:").append(sep)
+            .append("  ").append(before.replace(sep, sep.concat("  ")))
+            .append(sep).append(
                 String.format(
-                    "\nXML after XSL transformation (%d->%d chars):\n  ",
-                    xtory.before().toString().length(),
-                    after.toString().length()
+                    "XML after XSL transformation (%d->%d chars):",
+                    before.length(),
+                    later.length()
                 )
-            )
-            .append(after.toString().replace("\n", "\n  "));
+            ).append(sep).append("  ").append(later.replace(sep, sep.concat("  ")));
         this.summary = sum.toString();
         this.match = true;
         for (final Map.Entry<String, Boolean> ent : xpaths) {
@@ -139,8 +139,7 @@ public final class XtoryMatcher extends BaseMatcher<Xtory> {
         if (this.match) {
             this.extra.describeMismatch(story, desc);
         } else {
-            desc.appendText("\n").appendText(this.summary);
+            desc.appendText(System.lineSeparator()).appendText(this.summary);
         }
     }
-
 }

--- a/src/main/java/org/eolang/xax/XtoryMatcher.java
+++ b/src/main/java/org/eolang/xax/XtoryMatcher.java
@@ -6,8 +6,8 @@ package org.eolang.xax;
 
 import com.jcabi.xml.XML;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.Map;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -77,7 +77,7 @@ public final class XtoryMatcher extends BaseMatcher<Xtory> {
         Assumptions.assumeTrue(xtory.map().get("skip") == null);
         final XML after = xtory.xsline().pass(xtory.before());
         final Collection<Map.Entry<String, Boolean>> xpaths =
-            new LinkedList<>();
+            new ArrayList<>(0);
         int failures = 0;
         for (final String xpath : xtory.asserts()) {
             final boolean success = !after.nodes(xpath).isEmpty();

--- a/src/main/java/org/eolang/xax/package-info.java
+++ b/src/main/java/org/eolang/xax/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * XPath Assertions for XSL.
- *
  * @since 0.0.1
  */
 package org.eolang.xax;

--- a/src/test/java/org/eolang/xax/XtStickyTest.java
+++ b/src/test/java/org/eolang/xax/XtStickyTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link XtSticky}.
- *
  * @since 0.1.0
  */
 final class XtStickyTest {
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void parsesAndTransforms() throws Exception {
         final Xtory xtory = new XtSticky(
             new XtYaml(
@@ -32,5 +32,4 @@ final class XtStickyTest {
             XhtmlMatchers.hasXPaths(xtory.asserts())
         );
     }
-
 }

--- a/src/test/java/org/eolang/xax/XtStrictAfterTest.java
+++ b/src/test/java/org/eolang/xax/XtStrictAfterTest.java
@@ -14,13 +14,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link XtStrictAfter}.
- *
  * @since 0.1.0
  */
 final class XtStrictAfterTest {
 
     @Test
     @ExtendWith(WeAreOnline.class)
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void parsesAndTransforms() throws Exception {
         final Xtory xtory = new XtStrictAfter(
             new XtYaml(
@@ -35,5 +35,4 @@ final class XtStrictAfterTest {
             XhtmlMatchers.hasXPaths(xtory.asserts())
         );
     }
-
 }

--- a/src/test/java/org/eolang/xax/XtStrictBeforeTest.java
+++ b/src/test/java/org/eolang/xax/XtStrictBeforeTest.java
@@ -14,13 +14,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link XtStrictBefore}.
- *
  * @since 0.1.0
  */
 final class XtStrictBeforeTest {
 
     @Test
     @ExtendWith(WeAreOnline.class)
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void parsesAndTransforms() throws Exception {
         final Xtory xtory = new XtStrictBefore(
             new XtYaml(
@@ -35,5 +35,4 @@ final class XtStrictBeforeTest {
             XhtmlMatchers.hasXPaths(xtory.asserts())
         );
     }
-
 }

--- a/src/test/java/org/eolang/xax/XtStrictTest.java
+++ b/src/test/java/org/eolang/xax/XtStrictTest.java
@@ -14,13 +14,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link XtStrict}.
- *
  * @since 0.1.0
  */
 final class XtStrictTest {
 
     @Test
     @ExtendWith(WeAreOnline.class)
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void parsesAndTransforms() throws Exception {
         final Xtory xtory = new XtStrict(
             new XtYaml(
@@ -35,5 +35,4 @@ final class XtStrictTest {
             XhtmlMatchers.hasXPaths(xtory.asserts())
         );
     }
-
 }

--- a/src/test/java/org/eolang/xax/XtoryMatcherTest.java
+++ b/src/test/java/org/eolang/xax/XtoryMatcherTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Test case for {@link XtoryMatcher}.
- *
  * @since 0.1.0
  */
 final class XtoryMatcherTest {
@@ -96,5 +95,4 @@ final class XtoryMatcherTest {
             Matchers.not(new XtoryMatcher())
         );
     }
-
 }

--- a/src/test/java/org/eolang/xax/XtoryTest.java
+++ b/src/test/java/org/eolang/xax/XtoryTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Xtory}.
- *
  * @since 0.1.0
  */
 final class XtoryTest {
 
     @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void parsesAndTransforms() throws Exception {
         final Xtory xtory = new XtYaml(
             new TextOf(
@@ -30,5 +30,4 @@ final class XtoryTest {
             XhtmlMatchers.hasXPaths(xtory.asserts())
         );
     }
-
 }

--- a/src/test/java/org/eolang/xax/package-info.java
+++ b/src/test/java/org/eolang/xax/package-info.java
@@ -4,8 +4,7 @@
  */
 
 /**
- * XPath Assertions for XSL.
- *
+ * XPath Assertions for XSL (tests).
  * @since 0.0.1
  */
 package org.eolang.xax;

--- a/src/test/resources/org/eolang/xax/packs/simple-eo.yaml
+++ b/src/test/resources/org/eolang/xax/packs/simple-eo.yaml
@@ -3,8 +3,8 @@
 ---
 input: |
   # No comments.
-  [] > foo
-    QQ.io.stdout > @
-      "Hello, world!"
+  [x] > foo
+    x > @
 asserts:
-  - /program/objects/o
+  - /object[not(errors)]
+  - //o[@name='foo']


### PR DESCRIPTION
Picked this repo and gave it a refresh.

## What changed

### Parent POM
- `com.jcabi:parent`: 0.68.0 → 0.73.1

### Java dependencies
- `org.yaml:snakeyaml`: 2.4 → 2.6
- `com.jcabi:jcabi-xml`: 0.33.5 → 0.35.0
- `org.cactoos:cactoos`: 0.57.0 → 0.61.0
- `org.junit.jupiter:junit-jupiter-api`: 5.11.4 → 6.0.3 (now aligned with the parent's BOM)
- `net.sf.saxon:Saxon-HE`: 12.8 → 12.9
- `com.jcabi:jcabi-matchers`: 1.8.0 → 1.9.0
- `com.yegor256:jping`: 0.0.3 → 0.1.0
- `org.eolang:eo-parser`: 0.51.6 → 0.61.0

### Maven plugins
- `org.pitest:pitest-maven`: 1.20.0 → 1.23.1
- `com.qulice:qulice-maven-plugin`: 0.24.0 → 0.27.6

### GitHub Actions
- `actions/checkout`: v4 → v6
- `actions/setup-java`: v4 → v5
- `actions/cache`: v4 → v5
- `codecov/codecov-action`: v5 → v6
- `DavidAnson/markdownlint-cli2-action`: v20.0.0 → v23.2.0
- `crate-ci/typos`: v1.34.0 → v1.46.1
- `peter-evans/create-pull-request`: v7 → v8
- `fsfe/reuse-action`: v5 → v6

### CI matrix
- Dropped Java 11 (incompatible with JUnit 6) and added Java 21 alongside Java 17.

## Fixes that came with the upgrade

- `XtYaml`: `new XSLDocument(Paths.get(...))` now throws `IOException` rather than `FileNotFoundException` in jcabi-xml 0.35.0; updated the catch and import accordingly.
- `simple-eo.yaml`: the new eo-parser produces a different XMIR root element (`<object>` instead of `<program><objects>`) and rejects the old `[] > foo` / `QQ.io.stdout > @` snippet, so rewrote the input to use valid 0.61.0 EO and switched the xpath asserts to match the new schema.
- A handful of small style fixes (javadoc blank lines, fluent-call indentation, `System.lineSeparator()` instead of literal `\n`, `@FunctionalInterface`, `Map` instead of `ConcurrentHashMap`, suppressing the new `UnitTestContainsTooManyAsserts` rule for tests that genuinely have just one `assertThat`) to satisfy qulice 0.27.6.

`mvn clean install -Pqulice` is green locally on Java 21.