### PR TITLE
Drop unused qulice excludes; pom already on qulice 0.27.6 (latest)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,12 +169,6 @@
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
             <version>0.27.6</version>
-            <configuration>
-              <excludes combine.children="append">
-                <exclude>checkstyle:/src/site/resources/.*</exclude>
-                <exclude>duplicatefinder:.*</exclude>
-              </excludes>
-            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
## Summary

The task was "upgrade qulice to the latest version; fix all violations; don't suppress them." Investigation showed:

- `qulice-maven-plugin` is **already pinned to `0.27.6`** in `pom.xml` (qulice profile), which is the latest stable release on Maven Central (`maven-metadata.xml` lists `<latest>0.27.6</latest>`) and the latest GitHub release (`yegor256/qulice`).
- `mvn -Pqulice clean verify` is **already green** on master — no qulice violations to fix.

The only meaningful cleanup is removing two excludes in the qulice profile that were either dead or unjustified suppressions:

- `checkstyle:/src/site/resources/.*` — targets a directory that doesn't exist in this repository (`src/site/` is absent).
- `duplicatefinder:.*` — fully disabled the duplicate-finder check. With it removed, duplicate-finder runs and reports `No dependency problems found`.

After the change, `mvn -Pqulice clean verify` still completes with `BUILD SUCCESS` and `Qulice quality check completed`.

No false positives were observed against qulice 0.27.6 on this codebase, so no bug reports were filed to the qulice repo.

## Test plan

- [x] `mvn -Pqulice clean verify` → `BUILD SUCCESS`, all 14 tests pass (1 skipped by design), qulice + duplicate-finder both green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Am4QExseK8eTnY6yNupLu5)_